### PR TITLE
Fix functionality for inline elements

### DIFF
--- a/src/lib/overflow-reveal.directive.ts
+++ b/src/lib/overflow-reveal.directive.ts
@@ -93,6 +93,21 @@ export class NgxOverflowRevealDirective implements OnInit, OnDestroy {
   }
 
   private isOverflowing(el: HTMLElement): boolean {
+    const cs = getComputedStyle(el);
+    const display = cs.display;
+
+    // For pure inline elements (not inline-block, inline-flex, etc.), temporarily set to inline-block
+    // to get accurate overflow measurements. Pure inline elements don't have proper scrollWidth/clientWidth
+    // values for overflow detection as they don't establish a box model in the same way.
+    if (display === 'inline') {
+      const originalDisplay = el.style.display;
+      el.style.display = 'inline-block';
+      const hasOverflow = el.scrollWidth > el.clientWidth || el.scrollHeight > el.clientHeight;
+      // Restore original display (empty string to use CSS value)
+      el.style.display = originalDisplay;
+      return hasOverflow;
+    }
+
     return el.scrollWidth > el.clientWidth || el.scrollHeight > el.clientHeight;
   }
 


### PR DESCRIPTION
Inline elements (display: inline) don't have proper scrollWidth/clientWidth values for overflow detection. This fix temporarily sets them to inline-block to accurately measure overflow, then restores the original display value.

This allows the directive to work correctly on <span> and other inline elements that may not have display: inline-block explicitly set in CSS.